### PR TITLE
getJobCandidates fixes and getAllJobCandidates

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,7 @@
+# Authors ordered by first contribution
+
+| Name                   | Username                   | Email Address                  | Contribution                                          |
+|------------------------|----------------------------|--------------------------------|-------------------------------------------------------|
+| Aymen Mouelhi          | aymen-mouelhi              |                                | Owner                                                 |
+| Gary Moon (WordFence)  | garymoon                   | gary@wordfence.com             | getAllJobCandidates()                                 |
+

--- a/index.js
+++ b/index.js
@@ -153,7 +153,8 @@ Workable.prototype.getJobCandidates = function(subdomain, shortcode, stage, limi
 
     if (stage) {
         query += '&stage=' + stage;
-    } else if (since_id) {
+    }
+    if (since_id) {
         query += '&since_id=' + since_id;
     }
     return this._get(query, callback);


### PR DESCRIPTION
Hi Aymen,

I'm not sure whether or not it was intentional, but getJobCandidates didn't allow for specifying both since_id and stage at the same time, but I've confirmed it works and enabled that functionality.

I've also included a variant of the same function allowing for paging in the returned data. There are some comments there about a few things I was unsure of, so please read them before merging.

Thanks for the library!